### PR TITLE
Fix exception for empty creator's list

### DIFF
--- a/src/flixr/display.py
+++ b/src/flixr/display.py
@@ -90,13 +90,15 @@ def formatted(show):
 
     # creators
     creators = list(map(lambda x: bold(color(x, gradient[2])), show["creators"]))
-    if len(creators) == 1:
-        creators = creators[0]
-    elif len(creators) == 2:
-        creators = " & ".join(creators)
-    else:
-        creators = " & ".join([", ".join(creators[:-1]), creators[-1]])
-    output.append(f"Created by {creators}")
+    
+    if len(creators) > 0:
+        if len(creators) == 1:
+            creators = creators[0]
+        elif len(creators) == 2:
+            creators = " & ".join(creators)
+        else:
+            creators = " & ".join([", ".join(creators[:-1]), creators[-1]])
+        output.append(f"Created by {creators}")
 
     # Cast
     cast = list(map(lambda x: bold(color(x, gradient[2])), show["cast"]))


### PR DESCRIPTION
Hello there fellow binge watcher,

Api queries for certain shows lead to an empty list for the `show['url']}/crew` link. So even if the show exists, the code would throw an error simply because the "creators" list you construct is empty. (Say for a show like "erased" - pretty good anime btw ;) )

	Traceback (most recent call last):
	  File "/home/adi/anaconda3/envs/flixr/bin/flixr", line 8, in <module>
		sys.exit(main())
	  File "/home/adi/anaconda3/envs/flixr/lib/python3.6/site-packages/flixr/__main__.py", line 7, in main
		print(formatted(parse(search(Interface()()))))
	  File "/home/adi/anaconda3/envs/flixr/lib/python3.6/site-packages/flixr/display.py", line 98, in formatted
		creators = " & ".join([", ".join(creators[:-1]), creators[-1]])
	IndexError: list index out of range

This is hopefully a trivial and quick fix for the same (its just an if condition lmao). It would mitigate the exception, and displays info without the creators.

	ERASED
	An anime, fantasy, thriller, mystery show on Fuji TV (2016 - 2016)
	Starring Akemi Okamura, Minami Takayama, Emoto Tasuku & more
	Watch it here: http://bokumachi-anime.com/